### PR TITLE
Sample configuration for singing and publishing to maven central

### DIFF
--- a/.buildkite/configure_signing.sh
+++ b/.buildkite/configure_signing.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#see https://central.sonatype.org/publish/publish-gradle/#distributing-your-public-key
+
+set -e 
+
+mkdir -p /tmp
+keyring_file="/tmp/keyring.gpg"
+
+vault kv get --field="keyring" kv/ci-shared/release-eng/team-release-secrets/elasticsearch-java/gpg | base64 -d > $keyring_file
+signing_password=$(vault kv get --field="passphase" kv/ci-shared/release-eng/team-release-secrets/elasticsearch-java/gpg)
+signing_key=$(vault kv get --field="key_id" kv/ci-shared/release-eng/team-release-secrets/elasticsearch-java/gpg)
+
+maven_username=$(vault kv get --field="username" kv/ci-shared/release-eng/team-release-secrets/elasticsearch-java/maven_central)
+maven_password=$(vault kv get --field="password" kv/ci-shared/release-eng/team-release-secrets/elasticsearch-java/maven_central)
+
+cat > gradle.properties <<EOF
+signing.keyId=${signing_key: -8}
+signing.password=${signing_password}
+signing.secretKeyRingFile=${keyring_file}
+
+ossrhUsername=${maven_username}
+ossrhPassword=${maven_password}
+EOF
+

--- a/java-client-serverless/build.gradle.kts
+++ b/java-client-serverless/build.gradle.kts
@@ -28,12 +28,17 @@ plugins {
     `java-library`
     checkstyle
     `maven-publish`
+    signing
     id("com.github.jk1.dependency-license-report") version "2.2"
     id("de.thetaphi.forbiddenapis") version "3.4"
 }
 
 // GitHub Maven repo doesn't like 1.0.0+20231031-SNAPSHOT
 version = "1.0.0-20231031-SNAPSHOT"
+
+signing {
+    sign(publishing.publications)
+}
 
 java {
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -115,6 +120,7 @@ tasks.withType<Javadoc> {
     }
 }
 
+
 publishing {
     repositories {
         maven {
@@ -129,6 +135,15 @@ publishing {
             name = "Build"
             url = uri("${rootProject.buildDir}/repository")
         }
+
+	maven {
+            name = "MavenCentralSnapshot"
+            setUrl("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            credentials {
+                 username = providers.gradleProperty("ossrhUsername").getOrNull()
+                 password = providers.gradleProperty("ossrhPassword").getOrNull()
+           }
+       }
     }
 
     publications {


### PR DESCRIPTION
This is a sample configuration to implement signing and publishing to maven central using a buildkite pipeline.

Note: The script will only work in buildkite. It will work as-it is without any changes there.
It's recomended to change use the https://github.com/elastic/vault-secrets-buildkite-plugin in the pipeline instead of the vault cli in the script. 

I tested the signing locally and it works, the publishing fails with:
```
* What went wrong:
Execution failed for task ':java-client-serverless:publishMavenPublicationToMavenCentralSnapshotRepository'.
> Failed to publish publication 'maven' to repository 'MavenCentralSnapshot'
   > Could not PUT 'https://s01.oss.sonatype.org/content/repositories/snapshots/co/elastic/clients/elasticsearch-java-serverless/1.0.0-20231031-SNAPSHOT/maven-metadata.xml'. Received status code 401 from server: Unauthorized
```

But I tested that the credentials are passed correctly. 
It most likeley fails because not all requirements are ment, see: https://central.sonatype.org/publish/requirements/
You can compare the example pom with yours and lookg at the other requirements. At least the javadoc and source jars are missing.
